### PR TITLE
Add programmatic API

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,21 @@ Options:
   -h, --help                                     display help for command
 ```
 
+## Programmatic Usage
+
+You can use json-autotranslate in Node.js without spawning the CLI:
+
+```ts
+import { translate } from 'json-autotranslate';
+
+await translate({
+  inputDir: 'locales',
+  service: 'google-translate',
+});
+```
+
+All CLI options are available as camel-cased properties of the options object.
+
 ## Contributing
 
 If you'd like to contribute to this project, please feel free to open a pull

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "json-autotranslate",
   "description": "Translate a folder of JSON files containing translations into multiple languages.",
   "version": "1.16.1",
-  "main": "index.js",
+  "main": "lib/api.js",
   "license": "MIT",
   "scripts": {
     "start": "ts-node src/index.ts",

--- a/src/api.spec.ts
+++ b/src/api.spec.ts
@@ -1,0 +1,13 @@
+import { listServices, listMatchers } from './translate';
+
+describe('API exports', () => {
+  it('should expose list of services', () => {
+    expect(Array.isArray(listServices())).toBe(true);
+    expect(listServices().length).toBeGreaterThan(0);
+  });
+
+  it('should expose list of matchers', () => {
+    expect(Array.isArray(listMatchers())).toBe(true);
+    expect(listMatchers().length).toBeGreaterThan(0);
+  });
+});

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,1 @@
+export * from './translate';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,446 +2,64 @@
 
 import chalk from 'chalk';
 import commander from 'commander';
-import { flatten, unflatten } from 'flat';
-import * as fs from 'fs';
-import { omit } from 'lodash';
-import * as path from 'path';
-import { diff } from 'deep-object-diff';
-import ncp from 'ncp';
 
-import { serviceMap, TranslationService } from './services';
-import {
-  loadTranslations,
-  getAvailableLanguages,
-  fixSourceInconsistencies,
-  evaluateFilePath,
-  FileType,
-  DirectoryStructure,
-  TranslatableFile,
-} from './util/file-system';
-import { matcherMap } from './matchers';
+import { translate, listServices, listMatchers } from './translate';
 
 require('dotenv').config();
 
 commander
-  .option(
-    '-i, --input <inputDir>',
-    'the directory containing language directories',
-    '.',
-  )
-  .option(
-    '--exclude <exclude glob>',
-    'exclude files matching the given glob pattern',
-  )
-  .option(
-    '--cache <cacheDir>',
-    'set the cache directory',
-    '.json-autotranslate-cache',
-  )
-  .option(
-    '-l, --source-language <sourceLang>',
-    'specify the source language',
-    'en',
-  )
-  .option(
-    '-t, --type <key-based|natural|auto>',
-    `specify the file structure type`,
-    /^(key-based|natural|auto)$/,
-    'auto',
-  )
-  .option(
-    '-a, --with-arrays',
-    `enables support for arrays in files, but removes support for keys named 0, 1, 2, etc.`,
-  )
-  .option(
-    '-s, --service <service>',
-    `selects the service to be used for translation`,
-    'google-translate',
-  )
-  .option(
-    '-g, --glossaries [glossariesDir]',
-    `set the glossaries folder to be used by DeepL. Keep empty for automatic determination of matching glossary`,
-  )
-  .option(
-    '-a, --appName <appName>',
-    `specify the name of your app to distinguish DeepL glossaries (if sharing an API key between multiple projects)`,
-    'json-autotranslate',
-  )
-  .option(
-    '--context <context>',
-    `set the context that is used by DeepL for translations, for OpenAI it's the path to a JSON file`,
-  )
+  .option('-i, --input <inputDir>', 'the directory containing language directories', '.')
+  .option('--exclude <exclude glob>', 'exclude files matching the given glob pattern')
+  .option('--cache <cacheDir>', 'set the cache directory', '.json-autotranslate-cache')
+  .option('-l, --source-language <sourceLang>', 'specify the source language', 'en')
+  .option('-t, --type <key-based|natural|auto>', `specify the file structure type`, /^(key-based|natural|auto)$/, 'auto')
+  .option('-a, --with-arrays', `enables support for arrays in files, but removes support for keys named 0, 1, 2, etc.`)
+  .option('-s, --service <service>', `selects the service to be used for translation`, 'google-translate')
+  .option('-g, --glossaries [glossariesDir]', `set the glossaries folder to be used by DeepL. Keep empty for automatic determination of matching glossary`)
+  .option('-a, --appName <appName>', `specify the name of your app to distinguish DeepL glossaries (if sharing an API key between multiple projects)`, 'json-autotranslate')
+  .option('--context <context>', `set the context that is used by DeepL for translations, for OpenAI it's the path to a JSON file`)
   .option('--list-services', `outputs a list of available services`)
-  .option(
-    '-m, --matcher <matcher>',
-    `selects the matcher to be used for interpolations`,
-    'icu',
-  )
+  .option('-m, --matcher <matcher>', `selects the matcher to be used for interpolations`, 'icu')
   .option('--list-matchers', `outputs a list of available matchers`)
-  .option(
-    '-c, --config <value>',
-    'supply a config parameter (e.g. path to key file) to the translation service',
-  )
-  .option(
-    '-f, --fix-inconsistencies',
-    `automatically fixes inconsistent key-value pairs by setting the value to the key`,
-  )
-  .option(
-    '-d, --delete-unused-strings',
-    `deletes strings in translation files that don't exist in the template`,
-  )
-  .option(
-    '--directory-structure <default|ngx-translate>',
-    'the locale directory structure',
-  )
-  .option(
-    '--decode-escapes',
-    'decodes escaped HTML entities like &#39; into normal UTF-8 characters',
-  )
-  .option(
-    '-o, --overwrite',
-    'overwrite existing translations instead of skipping them',
-  )
+  .option('-c, --config <value>', 'supply a config parameter (e.g. path to key file) to the translation service')
+  .option('-f, --fix-inconsistencies', `automatically fixes inconsistent key-value pairs by setting the value to the key`)
+  .option('-d, --delete-unused-strings', `deletes strings in translation files that don't exist in the template`)
+  .option('--directory-structure <default|ngx-translate>', 'the locale directory structure')
+  .option('--decode-escapes', 'decodes escaped HTML entities like &#39; into normal UTF-8 characters')
+  .option('-o, --overwrite', 'overwrite existing translations instead of skipping them')
   .parse(process.argv);
-
-const translate = async (
-  inputDir: string = '.',
-  exclude: string | undefined = undefined,
-  cacheDir: string = '.json-autotranslate-cache',
-  sourceLang: string = 'en',
-  deleteUnusedStrings = false,
-  fileType: FileType = 'auto',
-  withArrays: boolean = false,
-  dirStructure: DirectoryStructure = 'default',
-  fixInconsistencies = false,
-  service: keyof typeof serviceMap = 'google-translate',
-  matcher: keyof typeof matcherMap = 'icu',
-  decodeEscapes = false,
-  config?: string,
-  glossariesDir?: string | boolean,
-  appName?: string,
-  context?: string,
-  overwrite: boolean = false,
-) => {
-  const workingDir = path.resolve(process.cwd(), inputDir);
-  const resolvedCacheDir = path.resolve(process.cwd(), cacheDir);
-  const availableLanguages = getAvailableLanguages(workingDir, dirStructure);
-  const targetLanguages = availableLanguages.filter((f) => f !== sourceLang);
-
-  if (!fs.existsSync(resolvedCacheDir)) {
-    fs.mkdirSync(resolvedCacheDir);
-    console.log(`🗂 Created the cache directory.`);
-  }
-
-  if (!availableLanguages.includes(sourceLang)) {
-    throw new Error(`The source language ${sourceLang} doesn't exist.`);
-  }
-
-  if (typeof serviceMap[service] === 'undefined') {
-    throw new Error(`The service ${service} doesn't exist.`);
-  }
-
-  if (typeof matcherMap[matcher] === 'undefined') {
-    throw new Error(`The matcher ${matcher} doesn't exist.`);
-  }
-
-  const translationService = serviceMap[service];
-
-  const templateFilePath = evaluateFilePath(
-    workingDir,
-    dirStructure,
-    sourceLang,
-  );
-
-  const templateFiles = loadTranslations(
-    templateFilePath,
-    exclude,
-    fileType,
-    withArrays,
-  );
-
-  if (templateFiles.length === 0) {
-    throw new Error(
-      `The source language ${sourceLang} doesn't contain any JSON files.`,
-    );
-  }
-
-  console.log(
-    chalk`Found {green.bold ${String(
-      targetLanguages.length,
-    )}} target language(s):`,
-  );
-  console.log(`-> ${targetLanguages.join(', ')}`);
-  console.log();
-
-  console.log(`🏭 Loading source files...`);
-  for (const file of templateFiles) {
-    console.log(chalk`├── ${String(file.name)} (${file.type})`);
-  }
-  console.log(chalk`└── {green.bold Done}`);
-  console.log();
-
-  console.log(`✨ Initializing ${translationService.name}...`);
-  await translationService.initialize(
-    config,
-    matcherMap[matcher],
-    decodeEscapes,
-    glossariesDir,
-    appName,
-    context,
-  );
-  console.log(chalk`└── {green.bold Done}`);
-  console.log();
-
-  if (!translationService.supportsLanguage(sourceLang)) {
-    throw new Error(
-      `${translationService.name} doesn't support the source language ${sourceLang}`,
-    );
-  }
-
-  console.log(`🔍 Looking for key-value inconsistencies in source files...`);
-  const inconsistentFiles: string[] = [];
-
-  for (const file of templateFiles.filter((f) => f.type === 'natural')) {
-    const inconsistentKeys = Object.keys(file.content).filter(
-      (key) => key !== file.content[key],
-    );
-
-    if (inconsistentKeys.length > 0) {
-      inconsistentFiles.push(file.name);
-      console.log(
-        chalk`├── {yellow.bold ${file.name} contains} {red.bold ${String(
-          inconsistentKeys.length,
-        )}} {yellow.bold inconsistent key(s)}`,
-      );
-    }
-  }
-
-  if (inconsistentFiles.length > 0) {
-    console.log(
-      chalk`└── {yellow.bold Found key-value inconsistencies in} {red.bold ${String(
-        inconsistentFiles.length,
-      )}} {yellow.bold file(s).}`,
-    );
-
-    console.log();
-
-    if (fixInconsistencies) {
-      console.log(`💚 Fixing inconsistencies...`);
-      fixSourceInconsistencies(
-        templateFilePath,
-        evaluateFilePath(resolvedCacheDir, dirStructure, sourceLang),
-      );
-      console.log(chalk`└── {green.bold Fixed all inconsistencies.}`);
-    } else {
-      console.log(
-        chalk`Please either fix these inconsistencies manually or supply the {green.bold -f} flag to automatically fix them.`,
-      );
-    }
-  } else {
-    console.log(chalk`└── {green.bold No inconsistencies found}`);
-  }
-  console.log();
-
-  console.log(`🔍 Looking for invalid keys in source files...`);
-  const invalidFiles: string[] = [];
-
-  for (const file of templateFiles.filter((f) => f.type === 'key-based')) {
-    const invalidKeys = Object.keys(file.originalContent).filter(
-      (k) => typeof file.originalContent[k] === 'string' && k.includes(' '),
-    );
-
-    if (invalidKeys.length > 0) {
-      invalidFiles.push(file.name);
-      console.log(
-        chalk`├── {yellow.bold ${file.name} contains} {red.bold ${String(
-          invalidKeys.length,
-        )}} {yellow.bold invalid key(s)}`,
-      );
-    }
-  }
-
-  if (invalidFiles.length) {
-    console.log(
-      chalk`└── {yellow.bold Found invalid keys in} {red.bold ${String(
-        invalidFiles.length,
-      )}} {yellow.bold file(s).}`,
-    );
-
-    console.log();
-    console.log(
-      chalk`It looks like you're trying to use the key-based mode on natural-language-style JSON files.`,
-    );
-    console.log(
-      chalk`Please make sure that your keys don't contain periods (.) or remove the {green.bold --type} / {green.bold -t} option.`,
-    );
-    console.log();
-    process.exit(1);
-  } else {
-    console.log(chalk`└── {green.bold No invalid keys found}`);
-  }
-  console.log();
-
-  let totalAddedTranslations = 0;
-  let totalRemovedTranslations = 0;
-
-  for (const language of targetLanguages) {
-    if (!translationService.supportsLanguage(language)) {
-      console.log(
-        chalk`🙈 {yellow.bold ${translationService.name} doesn't support} {red.bold ${language}}{yellow.bold . Skipping this language.}`,
-      );
-      console.log();
-      continue;
-    }
-
-    console.log(
-      chalk`💬 Translating strings from {green.bold ${sourceLang}} to {green.bold ${language}}...`,
-    );
-
-    const translateContent = createTranslator(
-      translationService,
-      service,
-      sourceLang,
-      language,
-      cacheDir,
-      workingDir,
-      dirStructure,
-      deleteUnusedStrings,
-      withArrays,
-      overwrite,
-    );
-
-    switch (dirStructure) {
-      case 'default':
-        const existingFiles = loadTranslations(
-          evaluateFilePath(workingDir, dirStructure, language),
-          exclude,
-          fileType,
-          withArrays,
-        );
-
-        if (deleteUnusedStrings) {
-          const templateFileNames = templateFiles.map((t) => t.name);
-          const deletableFiles = existingFiles.filter(
-            (f) => !templateFileNames.includes(f.name),
-          );
-
-          for (const file of deletableFiles) {
-            console.log(
-              chalk`├── {red.bold ${file.name} is no longer used and will be deleted.}`,
-            );
-
-            fs.unlinkSync(
-              path.resolve(
-                evaluateFilePath(workingDir, dirStructure, language),
-                file.name,
-              ),
-            );
-
-            const cacheFile = path.resolve(
-              evaluateFilePath(workingDir, dirStructure, language),
-              file.name,
-            );
-            if (fs.existsSync(cacheFile)) {
-              fs.unlinkSync(cacheFile);
-            }
-          }
-        }
-
-        for (const templateFile of templateFiles) {
-          process.stdout.write(`├── Translating ${templateFile.name}`);
-
-          const [addedTranslations, removedTranslations] =
-            await translateContent(
-              templateFile,
-              existingFiles.find((f) => f.name === templateFile.name),
-            );
-
-          totalAddedTranslations += addedTranslations;
-          totalRemovedTranslations += removedTranslations;
-        }
-        break;
-
-      case 'ngx-translate':
-        const sourceFile = templateFiles.find(
-          (f) => f.name === `${sourceLang}.json`,
-        );
-        if (!sourceFile) {
-          throw new Error('Could not find source file. This is a bug.');
-        }
-        const [addedTranslations, removedTranslations] = await translateContent(
-          sourceFile,
-          templateFiles.find((f) => f.name === `${language}.json`),
-        );
-
-        totalAddedTranslations += addedTranslations;
-        totalRemovedTranslations += removedTranslations;
-        break;
-    }
-
-    console.log(chalk`└── {green.bold All strings have been translated.}`);
-    console.log();
-  }
-
-  if (service !== 'dry-run') {
-    console.log('🗂 Caching source translation files...');
-    await new Promise((res, rej) =>
-      ncp(
-        evaluateFilePath(workingDir, dirStructure, sourceLang),
-        evaluateFilePath(resolvedCacheDir, dirStructure, sourceLang),
-        (err) => (err ? rej() : res(null)),
-      ),
-    );
-    console.log(chalk`└── {green.bold Translation files have been cached.}`);
-    console.log();
-  }
-
-  console.log(
-    chalk.green.bold(
-      `${totalAddedTranslations} new translations have been added!`,
-    ),
-  );
-
-  if (totalRemovedTranslations > 0) {
-    console.log(
-      chalk.green.bold(
-        `${totalRemovedTranslations} translations have been removed!`,
-      ),
-    );
-  }
-};
 
 if (commander.listServices) {
   console.log('Available services:');
-  console.log(Object.keys(serviceMap).join(', '));
+  console.log(listServices().join(', '));
   process.exit(0);
 }
 
 if (commander.listMatchers) {
   console.log('Available matchers:');
-  console.log(Object.keys(matcherMap).join(', '));
+  console.log(listMatchers().join(', '));
   process.exit(0);
 }
 
-translate(
-  commander.input,
-  commander.exclude,
-  commander.cache,
-  commander.sourceLanguage,
-  commander.deleteUnusedStrings,
-  commander.type,
-  commander.withArrays,
-  commander.directoryStructure,
-  commander.fixInconsistencies,
-  commander.service,
-  commander.matcher,
-  commander.decodeEscapes,
-  commander.config,
-  commander.glossaries,
-  commander.appName,
-  commander.context,
-  commander.overwrite,
-).catch((e: Error) => {
+translate({
+  inputDir: commander.input,
+  exclude: commander.exclude,
+  cacheDir: commander.cache,
+  sourceLanguage: commander.sourceLanguage,
+  deleteUnusedStrings: commander.deleteUnusedStrings,
+  type: commander.type,
+  withArrays: commander.withArrays,
+  directoryStructure: commander.directoryStructure,
+  fixInconsistencies: commander.fixInconsistencies,
+  service: commander.service,
+  matcher: commander.matcher,
+  decodeEscapes: commander.decodeEscapes,
+  config: commander.config,
+  glossariesDir: commander.glossaries,
+  appName: commander.appName,
+  context: commander.context,
+  overwrite: commander.overwrite,
+}).catch((e: Error) => {
   console.log();
   console.log(chalk.bgRed('An error has occurred:'));
   console.log(chalk.bgRed(e.message));
@@ -449,129 +67,3 @@ translate(
   console.log();
   process.exit(1);
 });
-
-function createTranslator(
-  translationService: TranslationService,
-  service: keyof typeof serviceMap,
-  sourceLang: string,
-  targetLang: string,
-  cacheDir: string,
-  workingDir: string,
-  dirStructure: DirectoryStructure,
-  deleteUnusedStrings: boolean,
-  withArrays: boolean,
-  overwrite,
-) {
-  return async (
-    sourceFile: TranslatableFile,
-    destinationFile: TranslatableFile | undefined,
-  ) => {
-    const cachePath = path.resolve(
-      evaluateFilePath(cacheDir, dirStructure, sourceLang),
-      sourceFile ? sourceFile.name : '',
-    );
-    let cacheDiff: string[] = [];
-    if (fs.existsSync(cachePath) && !fs.statSync(cachePath).isDirectory()) {
-      const cachedFile = flatten(
-        JSON.parse(fs.readFileSync(cachePath).toString().trim()),
-      ) as any;
-      const cDiff = diff(cachedFile, sourceFile.content);
-      cacheDiff = Object.keys(cDiff).filter((k) => cDiff[k]);
-      const changedItems = Object.keys(cacheDiff).length.toString();
-      process.stdout.write(
-        chalk` ({green.bold ${changedItems}} changes from cache)`,
-      );
-    }
-
-    const existingKeys = destinationFile
-      ? Object.keys(destinationFile.content)
-      : [];
-    const templateStrings = Object.keys(sourceFile.content);
-    const stringsToTranslate = templateStrings
-      .filter(
-        (key) =>
-          overwrite ||
-          !existingKeys.includes(key) ||
-          cacheDiff.includes(key) ||
-          (typeof sourceFile.content[key] == 'string' &&
-            !destinationFile?.content[key]),
-      )
-      .map((key) => ({
-        key,
-        value: sourceFile.type === 'key-based' ? sourceFile.content[key] : key,
-      }));
-
-    const unusedStrings = existingKeys.filter(
-      (key) => !templateStrings.includes(key),
-    );
-
-    const translatedStrings = await translationService.translateStrings(
-      stringsToTranslate,
-      sourceLang,
-      targetLang,
-    );
-
-    const newKeys = translatedStrings.reduce(
-      (acc, cur) => ({ ...acc, [cur.key]: cur.translated }),
-      {} as { [k: string]: string },
-    );
-
-    if (service !== 'dry-run') {
-      const existingTranslations = destinationFile
-        ? destinationFile.content
-        : {};
-
-      const translatedFile = {
-        ...omit(existingTranslations, deleteUnusedStrings ? unusedStrings : []),
-        ...newKeys,
-      };
-
-      const newContent =
-        JSON.stringify(
-          sourceFile.type === 'key-based'
-            ? unflatten(translatedFile, { object: !withArrays })
-            : translatedFile,
-          null,
-          2,
-        ) + `\n`;
-
-      fs.writeFileSync(
-        path.resolve(
-          evaluateFilePath(workingDir, dirStructure, targetLang),
-          destinationFile?.name ?? sourceFile.name,
-        ),
-        newContent,
-      );
-
-      const languageCachePath = evaluateFilePath(
-        cacheDir,
-        dirStructure,
-        targetLang,
-      );
-      if (!fs.existsSync(languageCachePath)) {
-        fs.mkdirSync(languageCachePath);
-      }
-      fs.writeFileSync(
-        path.resolve(
-          languageCachePath,
-          destinationFile?.name ?? sourceFile.name,
-        ),
-        JSON.stringify(translatedFile, null, 2) + '\n',
-      );
-    }
-
-    console.log(
-      deleteUnusedStrings && unusedStrings.length > 0
-        ? chalk` ({green.bold +${String(
-            translatedStrings.length,
-          )}}/{red.bold -${String(unusedStrings.length)}})`
-        : chalk` ({green.bold +${String(translatedStrings.length)}})`,
-    );
-
-    // Added translations and removed translations
-    return [
-      translatedStrings.length,
-      deleteUnusedStrings ? unusedStrings.length : 0,
-    ];
-  };
-}

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -1,0 +1,442 @@
+import chalk from 'chalk';
+import { flatten, unflatten } from 'flat';
+import * as fs from 'fs';
+import * as path from 'path';
+import { diff } from 'deep-object-diff';
+import { omit } from 'lodash';
+import ncp from 'ncp';
+
+import { serviceMap, TranslationService } from './services';
+import {
+  loadTranslations,
+  getAvailableLanguages,
+  fixSourceInconsistencies,
+  evaluateFilePath,
+  FileType,
+  DirectoryStructure,
+  TranslatableFile,
+} from './util/file-system';
+import { matcherMap } from './matchers';
+
+export interface TranslateOptions {
+  inputDir?: string;
+  exclude?: string;
+  cacheDir?: string;
+  sourceLanguage?: string;
+  deleteUnusedStrings?: boolean;
+  type?: FileType;
+  withArrays?: boolean;
+  directoryStructure?: DirectoryStructure;
+  fixInconsistencies?: boolean;
+  service?: keyof typeof serviceMap;
+  matcher?: keyof typeof matcherMap;
+  decodeEscapes?: boolean;
+  config?: string;
+  glossariesDir?: string | boolean;
+  appName?: string;
+  context?: string;
+  overwrite?: boolean;
+}
+
+export const listServices = (): string[] => Object.keys(serviceMap);
+export const listMatchers = (): string[] => Object.keys(matcherMap);
+
+function createTranslator(
+  translationService: TranslationService,
+  service: keyof typeof serviceMap,
+  sourceLang: string,
+  targetLang: string,
+  cacheDir: string,
+  workingDir: string,
+  dirStructure: DirectoryStructure,
+  deleteUnusedStrings: boolean,
+  withArrays: boolean,
+  overwrite: boolean,
+) {
+  return async (
+    sourceFile: TranslatableFile,
+    destinationFile: TranslatableFile | undefined,
+  ): Promise<[number, number]> => {
+    const cachePath = path.resolve(
+      evaluateFilePath(cacheDir, dirStructure, sourceLang),
+      sourceFile ? sourceFile.name : '',
+    );
+    let cacheDiff: string[] = [];
+    if (fs.existsSync(cachePath) && !fs.statSync(cachePath).isDirectory()) {
+      const cachedFile = flatten(
+        JSON.parse(fs.readFileSync(cachePath).toString().trim()),
+      ) as any;
+      const cDiff = diff(cachedFile, sourceFile.content);
+      cacheDiff = Object.keys(cDiff).filter((k) => cDiff[k]);
+      const changedItems = Object.keys(cacheDiff).length.toString();
+      process.stdout.write(
+        chalk` ({green.bold ${changedItems}} changes from cache)`,
+      );
+    }
+
+    const existingKeys = destinationFile ? Object.keys(destinationFile.content) : [];
+    const templateStrings = Object.keys(sourceFile.content);
+    const stringsToTranslate = templateStrings
+      .filter(
+        (key) =>
+          overwrite ||
+          !existingKeys.includes(key) ||
+          cacheDiff.includes(key) ||
+          (typeof sourceFile.content[key] == 'string' && !destinationFile?.content[key]),
+      )
+      .map((key) => ({
+        key,
+        value: sourceFile.type === 'key-based' ? (sourceFile.content as any)[key] : key,
+      }));
+
+    const unusedStrings = existingKeys.filter((key) => !templateStrings.includes(key));
+
+    const translatedStrings = await translationService.translateStrings(
+      stringsToTranslate,
+      sourceLang,
+      targetLang,
+    );
+
+    const newKeys = translatedStrings.reduce(
+      (acc, cur) => ({ ...acc, [cur.key]: cur.translated }),
+      {} as { [k: string]: string },
+    );
+
+    if (service !== 'dry-run') {
+      const existingTranslations = destinationFile ? destinationFile.content : {};
+
+      const translatedFile = {
+        ...omit(existingTranslations, deleteUnusedStrings ? unusedStrings : []),
+        ...newKeys,
+      };
+
+      const newContent =
+        JSON.stringify(
+          sourceFile.type === 'key-based'
+            ? unflatten(translatedFile, { object: !withArrays })
+            : translatedFile,
+          null,
+          2,
+        ) + `\n`;
+
+      fs.writeFileSync(
+        path.resolve(
+          evaluateFilePath(workingDir, dirStructure, targetLang),
+          destinationFile?.name ?? sourceFile.name,
+        ),
+        newContent,
+      );
+
+      const languageCachePath = evaluateFilePath(cacheDir, dirStructure, targetLang);
+      if (!fs.existsSync(languageCachePath)) {
+        fs.mkdirSync(languageCachePath);
+      }
+      fs.writeFileSync(
+        path.resolve(languageCachePath, destinationFile?.name ?? sourceFile.name),
+        JSON.stringify(translatedFile, null, 2) + '\n',
+      );
+    }
+
+    console.log(
+      deleteUnusedStrings && unusedStrings.length > 0
+        ? chalk` ({green.bold +${String(translatedStrings.length)}}/{red.bold -${String(
+            unusedStrings.length,
+          )}})`
+        : chalk` ({green.bold +${String(translatedStrings.length)}})`,
+    );
+
+    return [translatedStrings.length, deleteUnusedStrings ? unusedStrings.length : 0];
+  };
+}
+
+export async function translate(options: TranslateOptions = {}): Promise<void> {
+  const {
+    inputDir = '.',
+    exclude,
+    cacheDir = '.json-autotranslate-cache',
+    sourceLanguage = 'en',
+    deleteUnusedStrings = false,
+    type = 'auto',
+    withArrays = false,
+    directoryStructure = 'default',
+    fixInconsistencies = false,
+    service = 'google-translate',
+    matcher = 'icu',
+    decodeEscapes = false,
+    config,
+    glossariesDir,
+    appName,
+    context,
+    overwrite = false,
+  } = options;
+
+  const workingDir = path.resolve(process.cwd(), inputDir);
+  const resolvedCacheDir = path.resolve(process.cwd(), cacheDir);
+  const availableLanguages = getAvailableLanguages(workingDir, directoryStructure);
+  const targetLanguages = availableLanguages.filter((f) => f !== sourceLanguage);
+
+  if (!fs.existsSync(resolvedCacheDir)) {
+    fs.mkdirSync(resolvedCacheDir);
+    console.log(`🗂 Created the cache directory.`);
+  }
+
+  if (!availableLanguages.includes(sourceLanguage)) {
+    throw new Error(`The source language ${sourceLanguage} doesn't exist.`);
+  }
+
+  if (typeof serviceMap[service] === 'undefined') {
+    throw new Error(`The service ${service} doesn't exist.`);
+  }
+
+  if (typeof matcherMap[matcher] === 'undefined') {
+    throw new Error(`The matcher ${matcher} doesn't exist.`);
+  }
+
+  const translationService = serviceMap[service];
+
+  const templateFilePath = evaluateFilePath(
+    workingDir,
+    directoryStructure,
+    sourceLanguage,
+  );
+
+  const templateFiles = loadTranslations(
+    templateFilePath,
+    exclude,
+    type,
+    withArrays,
+  );
+
+  if (templateFiles.length === 0) {
+    throw new Error(`The source language ${sourceLanguage} doesn't contain any JSON files.`);
+  }
+
+  console.log(
+    chalk`Found {green.bold ${String(targetLanguages.length)}} target language(s):`,
+  );
+  console.log(`-> ${targetLanguages.join(', ')}`);
+  console.log();
+
+  console.log(`🏭 Loading source files...`);
+  for (const file of templateFiles) {
+    console.log(chalk`├── ${String(file.name)} (${file.type})`);
+  }
+  console.log(chalk`└── {green.bold Done}`);
+  console.log();
+
+  console.log(`✨ Initializing ${translationService.name}...`);
+  await translationService.initialize(
+    config,
+    matcherMap[matcher],
+    decodeEscapes,
+    glossariesDir,
+    appName,
+    context,
+  );
+  console.log(chalk`└── {green.bold Done}`);
+  console.log();
+
+  if (!translationService.supportsLanguage(sourceLanguage)) {
+    throw new Error(
+      `${translationService.name} doesn't support the source language ${sourceLanguage}`,
+    );
+  }
+
+  console.log(`🔍 Looking for key-value inconsistencies in source files...`);
+  const inconsistentFiles: string[] = [];
+
+  for (const file of templateFiles.filter((f) => f.type === 'natural')) {
+    const inconsistentKeys = Object.keys(file.content).filter((key) => key !== (file.content as any)[key]);
+
+    if (inconsistentKeys.length > 0) {
+      inconsistentFiles.push(file.name);
+      console.log(
+        chalk`├── {yellow.bold ${file.name} contains} {red.bold ${String(
+          inconsistentKeys.length,
+        )}} {yellow.bold inconsistent key(s)}`,
+      );
+    }
+  }
+
+  if (inconsistentFiles.length > 0) {
+    console.log(
+      chalk`└── {yellow.bold Found key-value inconsistencies in} {red.bold ${String(
+        inconsistentFiles.length,
+      )}} {yellow.bold file(s).}`,
+    );
+
+    console.log();
+
+    if (fixInconsistencies) {
+      console.log(`💚 Fixing inconsistencies...`);
+      fixSourceInconsistencies(
+        templateFilePath,
+        evaluateFilePath(resolvedCacheDir, directoryStructure, sourceLanguage),
+      );
+      console.log(chalk`└── {green.bold Fixed all inconsistencies.}`);
+    } else {
+      console.log(
+        chalk`Please either fix these inconsistencies manually or supply the {green.bold -f} flag to automatically fix them.`,
+      );
+    }
+  } else {
+    console.log(chalk`└── {green.bold No inconsistencies found}`);
+  }
+  console.log();
+
+  console.log(`🔍 Looking for invalid keys in source files...`);
+  const invalidFiles: string[] = [];
+
+  for (const file of templateFiles.filter((f) => f.type === 'key-based')) {
+    const invalidKeys = Object.keys(file.originalContent).filter(
+      (k) => typeof (file.originalContent as any)[k] === 'string' && k.includes(' '),
+    );
+
+    if (invalidKeys.length > 0) {
+      invalidFiles.push(file.name);
+      console.log(
+        chalk`├── {yellow.bold ${file.name} contains} {red.bold ${String(
+          invalidKeys.length,
+        )}} {yellow.bold invalid key(s)}`,
+      );
+    }
+  }
+
+  if (invalidFiles.length) {
+    console.log(
+      chalk`└── {yellow.bold Found invalid keys in} {red.bold ${String(
+        invalidFiles.length,
+      )}} {yellow.bold file(s).}`,
+    );
+
+    console.log();
+    console.log(
+      chalk`It looks like you're trying to use the key-based mode on natural-language-style JSON files.`,
+    );
+    console.log(
+      chalk`Please make sure that your keys don't contain periods (.) or remove the {green.bold --type} / {green.bold -t} option.`,
+    );
+    console.log();
+    process.exit(1);
+  } else {
+    console.log(chalk`└── {green.bold No invalid keys found}`);
+  }
+  console.log();
+
+  let totalAddedTranslations = 0;
+  let totalRemovedTranslations = 0;
+
+  for (const language of targetLanguages) {
+    if (!translationService.supportsLanguage(language)) {
+      console.log(
+        chalk`🙈 {yellow.bold ${translationService.name} doesn't support} {red.bold ${language}}{yellow.bold . Skipping this language.}`,
+      );
+      console.log();
+      continue;
+    }
+
+    console.log(
+      chalk`💬 Translating strings from {green.bold ${sourceLanguage}} to {green.bold ${language}}...`,
+    );
+
+    const translateContent = createTranslator(
+      translationService,
+      service,
+      sourceLanguage,
+      language,
+      cacheDir,
+      workingDir,
+      directoryStructure,
+      deleteUnusedStrings,
+      withArrays,
+      overwrite,
+    );
+
+    switch (directoryStructure) {
+      case 'default':
+        const existingFiles = loadTranslations(
+          evaluateFilePath(workingDir, directoryStructure, language),
+          exclude,
+          type,
+          withArrays,
+        );
+
+        if (deleteUnusedStrings) {
+          const templateFileNames = templateFiles.map((t) => t.name);
+          const deletableFiles = existingFiles.filter((f) => !templateFileNames.includes(f.name));
+
+          for (const file of deletableFiles) {
+            console.log(
+              chalk`├── {red.bold ${file.name} is no longer used and will be deleted.}`,
+            );
+
+            fs.unlinkSync(
+              path.resolve(
+                evaluateFilePath(workingDir, directoryStructure, language),
+                file.name,
+              ),
+            );
+
+            const cacheFile = path.resolve(
+              evaluateFilePath(workingDir, directoryStructure, language),
+              file.name,
+            );
+            if (fs.existsSync(cacheFile)) {
+              fs.unlinkSync(cacheFile);
+            }
+          }
+        }
+
+        for (const templateFile of templateFiles) {
+          process.stdout.write(`├── Translating ${templateFile.name}`);
+
+          const [addedTranslations, removedTranslations] = await translateContent(
+            templateFile,
+            existingFiles.find((f) => f.name === templateFile.name),
+          );
+
+          totalAddedTranslations += addedTranslations;
+          totalRemovedTranslations += removedTranslations;
+        }
+        break;
+
+      case 'ngx-translate':
+        const sourceFile = templateFiles.find((f) => f.name === `${sourceLanguage}.json`);
+        if (!sourceFile) {
+          throw new Error('Could not find source file. This is a bug.');
+        }
+        const [addedTranslations, removedTranslations] = await translateContent(
+          sourceFile,
+          templateFiles.find((f) => f.name === `${language}.json`),
+        );
+
+        totalAddedTranslations += addedTranslations;
+        totalRemovedTranslations += removedTranslations;
+        break;
+    }
+
+    console.log(chalk`└── {green.bold All strings have been translated.}`);
+    console.log();
+  }
+
+  if (service !== 'dry-run') {
+    console.log('🗂 Caching source translation files...');
+    await new Promise((res, rej) =>
+      ncp(
+        evaluateFilePath(workingDir, directoryStructure, sourceLanguage),
+        evaluateFilePath(resolvedCacheDir, directoryStructure, sourceLanguage),
+        (err) => (err ? rej(err) : res(null)),
+      ),
+    );
+    console.log(chalk`└── {green.bold Translation files have been cached.}`);
+    console.log();
+  }
+
+  console.log(chalk.green.bold(`${totalAddedTranslations} new translations have been added!`));
+
+  if (totalRemovedTranslations > 0) {
+    console.log(
+      chalk.green.bold(`${totalRemovedTranslations} translations have been removed!`),
+    );
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "skipLibCheck": true,
     "target": "ESNext"
   },
-  "files": ["src/index.ts"]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- expose library API in `translate.ts` with typed options
- switch CLI implementation to use new API
- update TypeScript build config
- document programmatic usage
- add simple tests for API helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68811341b2088328ba13911906c4804c